### PR TITLE
Add Measurements

### DIFF
--- a/common/experimental.yaml
+++ b/common/experimental.yaml
@@ -12,3 +12,21 @@ datasets:
       reftype: object
     doc: Reference to the VectorData object that contains the enumerable elements
 
+datasets:
+- data_type_def: Measurement
+  data_type_inc: VectorData
+  dtype: numeric
+  doc: Data that are stored according to one dtype, but can be coerced by a
+    scaling factor and offset into another dtype representing the true units
+    of the measurement.
+  attributes:
+  - name: offset
+    dtype: numeric
+      target_type: VectorData
+      reftype: object
+    doc: Factor that is added to shift the values of the stored data prior to scaling.
+  - name: conversion_factor
+    dtype: numeric
+      target_type: VectorData
+      reftype: object
+    doc: Scalar multiple applied to all data shifted by offset.


### PR DESCRIPTION
## Summary of changes

- Very basic first attempt to get the ball rolling on this. We want to add a super general data type for representing Measurements as they differ from their internal storage type vs. their intended use.

Example: I store my electrical (Volts) data in a dataset as int16, and attach a conversion factor of 0.195 and offset of -32768. To coerce to scientific units, take a single data point in the dataset and add the offset, then multiply by the factor. See [Intan documentation](https://intantech.com/files/Intan_RHS2000_data_file_formats.pdf) for the actual use case of this.

First time doing this kind of thing, so let me know what all needs to be changed in addition to the to-do list below.


## PR checklist for schema changes

Added to the to-do list

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [ ] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` to the next version with the suffix "-alpha"
- [ ] Add a new section in the release notes for the new version with the date "Upcoming"
- [ ] Add release notes for the PR to `docs/source/format_release_notes.rst`

<!-- See https://hdmf-common-schema.readthedocs.io/en/latest/software_process.html for more details. -->
